### PR TITLE
fix: don't render an empty paragraph when the callout body is empty

### DIFF
--- a/.changeset/gentle-drinks-relate.md
+++ b/.changeset/gentle-drinks-relate.md
@@ -1,0 +1,5 @@
+---
+"@r4ai/remark-callout": minor
+---
+
+Don't render an empty paragraph when the callout body is empty

--- a/packages/remark-callout/src/plugin.test.ts
+++ b/packages/remark-callout/src/plugin.test.ts
@@ -229,6 +229,56 @@ describe("remarkCallout", () => {
     expect(callout).toBe(null);
   });
 
+  test("callout with title and without body", async () => {
+    const md = dedent`
+      > [!note] title here
+    `;
+
+    const { html } = await process(md);
+    const doc = parser.parseFromString(html, "text/html");
+
+    const callout = doc.querySelector("[data-callout]");
+    expect(callout).not.toBe(null);
+    expect(callout?.getAttribute("data-callout-type")).toBe("note");
+    expect(callout?.tagName.toLowerCase()).toBe("div");
+    expect(callout?.getAttribute("open")).toBe(null);
+    expect(callout?.children.length).toBe(2);
+
+    const calloutTitle = callout?.querySelector("[data-callout-title]");
+    expect(calloutTitle).not.toBe(null);
+    expect(calloutTitle?.textContent).toBe("title here");
+
+    const calloutBody = callout?.querySelector("[data-callout-body]");
+    expect(calloutBody).not.toBe(null);
+    expect(calloutBody?.textContent?.trim()).toBe("");
+    expect(calloutBody?.children.length).toBe(0);
+  });
+
+  test("callout without title and body", async () => {
+    const md = dedent`
+      > [!note]
+    `;
+
+    const { html } = await process(md);
+    const doc = parser.parseFromString(html, "text/html");
+
+    const callout = doc.querySelector("[data-callout]");
+    expect(callout).not.toBe(null);
+    expect(callout?.getAttribute("data-callout-type")).toBe("note");
+    expect(callout?.tagName.toLowerCase()).toBe("div");
+    expect(callout?.getAttribute("open")).toBe(null);
+    expect(callout?.children.length).toBe(2);
+
+    const calloutTitle = callout?.querySelector("[data-callout-title]");
+    expect(calloutTitle).not.toBe(null);
+    expect(calloutTitle?.textContent).toBe("Note");
+
+    const calloutBody = callout?.querySelector("[data-callout-body]");
+    expect(calloutBody).not.toBe(null);
+    expect(calloutBody?.textContent?.trim()).toBe("");
+    expect(calloutBody?.children.length).toBe(0);
+  });
+
   test("callout with title consisting of multiple nodes", async () => {
     const md = dedent`
       > [!note] The **reason** for why _this_ ~~is~~ \`true\` when $a=1$.

--- a/packages/remark-callout/src/plugin.ts
+++ b/packages/remark-callout/src/plugin.ts
@@ -369,7 +369,10 @@ export const remarkCallout: Plugin<[Options?], mdast.Root> = (_options) => {
               ...options.body(calloutData).properties,
             },
           },
-          children: bodyNode,
+          children:
+            bodyNode.length > 1 || bodyNode[0].children.length > 0
+              ? bodyNode
+              : [],
         },
       ];
     });


### PR DESCRIPTION
fix #134 

Fixed the issue where an empty paragraph was rendered when the callout body was empty. As a result, empty paragraphs will no longer be rendered for callouts without a title.

For insance,

```md
> [!note]
```

yieds:

`before`:
```html
<div data-callout data-callout-type="note">
  <div data-callout-title>Note</div>
  <div data-callout-body>
    <p></p>
  </div>
</div>
```

`after`:
```html
<div data-callout="" data-callout-type="note">
  <div data-callout-title="">Note</div>
  <div data-callout-body="">
  </div>
</div>
```