### PR TITLE
fix: skip empty callout body

### DIFF
--- a/.changeset/curly-maps-collect.md
+++ b/.changeset/curly-maps-collect.md
@@ -1,0 +1,5 @@
+---
+"@r4ai/remark-callout": minor
+---
+
+Don't render callout body when it is empty.

--- a/packages/remark-callout/src/plugin.test.ts
+++ b/packages/remark-callout/src/plugin.test.ts
@@ -242,16 +242,14 @@ describe("remarkCallout", () => {
     expect(callout?.getAttribute("data-callout-type")).toBe("note");
     expect(callout?.tagName.toLowerCase()).toBe("div");
     expect(callout?.getAttribute("open")).toBe(null);
-    expect(callout?.children.length).toBe(2);
+    expect(callout?.children.length).toBe(1);
 
     const calloutTitle = callout?.querySelector("[data-callout-title]");
     expect(calloutTitle).not.toBe(null);
     expect(calloutTitle?.textContent).toBe("title here");
 
     const calloutBody = callout?.querySelector("[data-callout-body]");
-    expect(calloutBody).not.toBe(null);
-    expect(calloutBody?.textContent?.trim()).toBe("");
-    expect(calloutBody?.children.length).toBe(0);
+    expect(calloutBody).toBe(null);
   });
 
   test("callout without title and body", async () => {
@@ -260,6 +258,7 @@ describe("remarkCallout", () => {
     `;
 
     const { html } = await process(md);
+    console.log(html);
     const doc = parser.parseFromString(html, "text/html");
 
     const callout = doc.querySelector("[data-callout]");
@@ -267,16 +266,14 @@ describe("remarkCallout", () => {
     expect(callout?.getAttribute("data-callout-type")).toBe("note");
     expect(callout?.tagName.toLowerCase()).toBe("div");
     expect(callout?.getAttribute("open")).toBe(null);
-    expect(callout?.children.length).toBe(2);
+    expect(callout?.children.length).toBe(1);
 
     const calloutTitle = callout?.querySelector("[data-callout-title]");
     expect(calloutTitle).not.toBe(null);
     expect(calloutTitle?.textContent).toBe("Note");
 
     const calloutBody = callout?.querySelector("[data-callout-body]");
-    expect(calloutBody).not.toBe(null);
-    expect(calloutBody?.textContent?.trim()).toBe("");
-    expect(calloutBody?.children.length).toBe(0);
+    expect(calloutBody).toBe(null);
   });
 
   test("callout with title consisting of multiple nodes", async () => {

--- a/packages/remark-callout/src/plugin.test.ts
+++ b/packages/remark-callout/src/plugin.test.ts
@@ -258,7 +258,6 @@ describe("remarkCallout", () => {
     `;
 
     const { html } = await process(md);
-    console.log(html);
     const doc = parser.parseFromString(html, "text/html");
 
     const callout = doc.querySelector("[data-callout]");

--- a/packages/remark-callout/src/plugin.ts
+++ b/packages/remark-callout/src/plugin.ts
@@ -359,9 +359,9 @@ export const remarkCallout: Plugin<[Options?], mdast.Root> = (_options) => {
       }
 
       // Add body and title to callout root node children
-      node.children = [
-        titleNode,
-        {
+      node.children = [titleNode];
+      if (bodyNode.length > 1 || bodyNode[0].children.length > 0) {
+        node.children.push({
           type: "blockquote",
           data: {
             hName: options.body(calloutData).tagName,
@@ -369,12 +369,9 @@ export const remarkCallout: Plugin<[Options?], mdast.Root> = (_options) => {
               ...options.body(calloutData).properties,
             },
           },
-          children:
-            bodyNode.length > 1 || bodyNode[0].children.length > 0
-              ? bodyNode
-              : [],
-        },
-      ];
+          children: bodyNode,
+        });
+      }
     });
   };
 };


### PR DESCRIPTION
fix #134 

Don't render callout body when it is empty.

For insance,

```md
> [!note]
```

yieds:

`before`:
```html
<div data-callout data-callout-type="note">
  <div data-callout-title>Note</div>
  <div data-callout-body>
  </div>
</div>
```

`after`:
```html
<div data-callout="" data-callout-type="note">
  <div data-callout-title="">Note</div>
</div>
```