### PR TITLE
feat: add `options.titleInner` to specify the HTML element that wraps the text of the callout title

### DIFF
--- a/.changeset/fresh-mirrors-walk.md
+++ b/.changeset/fresh-mirrors-walk.md
@@ -1,0 +1,5 @@
+---
+"@r4ai/remark-callout": minor
+---
+
+Add `options.titleInner` to specify the HTML element that wraps the text of the callout title

--- a/packages/remark-callout/README.md
+++ b/packages/remark-callout/README.md
@@ -250,6 +250,22 @@ export type OptionsBuilder<N> = {
   title?: N;
 
   /**
+   * The inner title node of the callout.
+   *
+   * @default
+   * (callout, options) =>
+   *   options.icon(callout) == null && options.foldIcon(callout) == null
+   *     ? undefined
+   *     : {
+   *         tagName: "div",
+   *         properties: {
+   *           dataCalloutTitleInner: true,
+   *         },
+   *       },
+   */
+  titleInner?: WithOptions<Optional<N>>;
+
+  /**
    * The body node of the callout.
    *
    * @default
@@ -392,6 +408,16 @@ export type WithChildren<N> = N extends (...args: any) => any
       | string;
 
 // biome-ignore lint/suspicious/noExplicitAny: any is necessary for checking if T is a function
+export type WithOptions<T> = T extends (...args: any) => any
+  ? (
+      ...args: [
+        ...Parameters<T>,
+        options: Required<OptionsBuilder<NodeOptionsFunction>>,
+      ]
+    ) => WithOptions<ReturnType<T>>
+  : T;
+
+// biome-ignore lint/suspicious/noExplicitAny: any is necessary for checking if T is a function
 export type Optional<T> = T extends (args: any) => any
   ? (...args: Parameters<T>) => Optional<ReturnType<T>>
   : T | undefined;
@@ -416,6 +442,15 @@ export const defaultOptions: Required<Options> = {
       dataCalloutTitle: true,
     },
   }),
+  titleInner: (callout, options) =>
+    options.icon(callout) == null && options.foldIcon(callout) == null
+      ? undefined
+      : {
+          tagName: "div",
+          properties: {
+            dataCalloutTitleInner: true,
+          },
+        },
   icon: () => undefined,
   foldIcon: () => undefined,
   body: () => ({

--- a/packages/remark-callout/README.md
+++ b/packages/remark-callout/README.md
@@ -252,6 +252,44 @@ export type OptionsBuilder<N> = {
   /**
    * The inner title node of the callout.
    *
+   * This node is used to wrap the text content of the title.
+   *
+   * - If `undefined`, title text is not wrapped.
+   *
+   *   Example output:
+   *
+   *   ```html
+   *   <div data-callout data-callout-type="abstract">
+   *     <div data-callout-title>
+   *       <div data-callout-icon>😎</div>
+   *       Title
+   *     </div>
+   *   </div>
+   *   ````
+   *
+   * - If a `object`, the object used as a node to wrap the title text.
+   *
+   *   Example output with options `{ tagName: "div", properties: { dataCalloutTitleInner: true } }`:
+   *
+   *   ```html
+   *   <div data-callout data-callout-type="abstract">
+   *     <div data-callout-title>
+   *       <div data-callout-icon>😎</div>
+   *       <div data-callout-title-inner>Title</div>
+   *     </div>
+   *   </div>
+   *   ```
+   *
+   * @example
+   * () => undefined  // the title text will not be wrapped
+   *
+   * @example
+   * // the title text will be wrapped in a div with the class "callout-title-inner"
+   * () => ({
+   *   tagName: "div",
+   *   properties: { className: "callout-title-inner" },
+   * })
+   *
    * @default
    * (callout, options) =>
    *   options.icon(callout) == null && options.foldIcon(callout) == null

--- a/packages/remark-callout/src/plugin.test.ts
+++ b/packages/remark-callout/src/plugin.test.ts
@@ -535,6 +535,34 @@ describe("remarkCallout", () => {
     expect(calloutTitle?.textContent).toBe("title here");
   });
 
+  test("options.titleInner", async () => {
+    const md = dedent`
+      > [!warn] title here
+      > body here
+    `;
+
+    const { html } = await process(md, {
+      titleInner: () => ({
+        tagName: "div",
+        properties: {
+          className: "callout-title-inner",
+        },
+      }),
+    });
+
+    const doc = parser.parseFromString(html, "text/html");
+
+    const title = doc.querySelector("[data-callout-title]");
+    expect(title).not.toBe(null);
+
+    const titleInner = title?.querySelector(".callout-title-inner");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
+  });
+
   test("options.icon when children is hast", async () => {
     const md = dedent`
       > [!note] title here
@@ -588,6 +616,13 @@ describe("remarkCallout", () => {
     const iconSvg = icon?.querySelector("svg");
     expect(iconSvg).not.toBe(null);
     expect(iconSvg?.getAttribute("class")).toBe("lucide-pencil");
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.icon when children is string", async () => {
@@ -619,6 +654,13 @@ describe("remarkCallout", () => {
     const iconSvg = icon?.querySelector("svg");
     expect(iconSvg).not.toBe(null);
     expect(iconSvg?.getAttribute("class")).toBe("lucide-circle-alert");
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.icon when icon is string", async () => {
@@ -638,6 +680,13 @@ describe("remarkCallout", () => {
     const svgIcon = title?.querySelector("svg");
     expect(svgIcon).not.toBe(null);
     expect(svgIcon?.getAttribute("class")).toBe("lucide-pencil");
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.icon when icon is undefined", async () => {
@@ -652,8 +701,17 @@ describe("remarkCallout", () => {
 
     const doc = parser.parseFromString(html, "text/html");
 
-    const svgIcon = doc.querySelector("svg");
+    const title = doc.querySelector("[data-callout-title]");
+
+    const svgIcon = title?.querySelector("svg");
     expect(svgIcon).toBe(null);
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).toBe(null);
+    expect(title?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.foldIcon when children is hast", async () => {
@@ -713,6 +771,13 @@ describe("remarkCallout", () => {
     expect(foldIconSvg?.getAttribute("class")).toBe(
       "lucide lucide-chevron-right",
     );
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.foldIcon when children is string", async () => {
@@ -747,6 +812,13 @@ describe("remarkCallout", () => {
     expect(foldIconSvg?.getAttribute("class")).toBe(
       "lucide lucide-chevron-right",
     );
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.foldIcon when icon is string", async () => {
@@ -769,6 +841,13 @@ describe("remarkCallout", () => {
     expect(foldIconSvg?.getAttribute("class")).toBe(
       "lucide lucide-chevron-right",
     );
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).not.toBe(null);
+    expect(titleInner?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.foldIcon when icon is undefined", async () => {
@@ -783,8 +862,17 @@ describe("remarkCallout", () => {
 
     const doc = parser.parseFromString(html, "text/html");
 
+    const title = doc.querySelector("[data-callout-title]");
+
     const foldIconSvg = doc.querySelector("svg");
     expect(foldIconSvg).toBe(null);
+
+    const titleInner = title?.querySelector("[data-callout-title-inner]");
+    expect(titleInner).toBe(null);
+    expect(title?.textContent).toBe("title here");
+
+    const body = doc.querySelector("[data-callout-body]");
+    expect(body?.children[0].textContent).toBe("body here");
   });
 
   test("options.callouts", async () => {

--- a/packages/remark-callout/src/plugin.ts
+++ b/packages/remark-callout/src/plugin.ts
@@ -39,6 +39,44 @@ export type OptionsBuilder<N> = {
   /**
    * The inner title node of the callout.
    *
+   * This node is used to wrap the text content of the title.
+   *
+   * - If `undefined`, title text is not wrapped.
+   *
+   *   Example output:
+   *
+   *   ```html
+   *   <div data-callout data-callout-type="abstract">
+   *     <div data-callout-title>
+   *       <div data-callout-icon>😎</div>
+   *       Title
+   *     </div>
+   *   </div>
+   *   ````
+   *
+   * - If a `object`, the object used as a node to wrap the title text.
+   *
+   *   Example output with options `{ tagName: "div", properties: { dataCalloutTitleInner: true } }`:
+   *
+   *   ```html
+   *   <div data-callout data-callout-type="abstract">
+   *     <div data-callout-title>
+   *       <div data-callout-icon>😎</div>
+   *       <div data-callout-title-inner>Title</div>
+   *     </div>
+   *   </div>
+   *   ```
+   *
+   * @example
+   * () => undefined  // the title text will not be wrapped
+   *
+   * @example
+   * // the title text will be wrapped in a div with the class "callout-title-inner"
+   * () => ({
+   *   tagName: "div",
+   *   properties: { className: "callout-title-inner" },
+   * })
+   *
    * @default
    * (callout, options) =>
    *   options.icon(callout) == null && options.foldIcon(callout) == null


### PR DESCRIPTION
close #133 

Add `options.titleInner` to specify the HTML element that wraps the text of the callout title.

This option is set by default as follows:

- If an icon exists in the title due to `options.icon` or `options.foldIcon`, the text will be wrapped in an element with `{tagName: "div", properties: {dataCalloutTitleInner: true}}`.
- If there is no icon, the text will be rendered as is without wrapping.

```ts
{
  titleInner: (callout, options) =>
    options.icon(callout) == null && options.foldIcon(callout) == null
      ? undefined
      : {
          tagName: "div",
          properties: {
            dataCalloutTitleInner: true,
          },
        },
  // other default options...
}
```

Following is an example output of callout with icon:

```html
<div data-callout data-callout-type="warn">
    <div data-callout-title>
        <div data-callout-icon><svg class="lucide-circle-alert" xmlns="http://www.w3.org/2000/svg" width="24"
                height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                stroke-linecap="round" stroke-linejoin="round">
                <circle cx="12" cy="12" r="10"></circle>
                <line x1="12" x2="12" y1="8" y2="12"></line>
                <line x1="12" x2="12.01" y1="16" y2="16"></line>
            </svg></div>
        <div data-callout-title-inner>title here</div>
    </div>
    <div data-callout-body>
        <p>body here</p>
    </div>
</div>
```