### PR TITLE
chore: bump nodejs to 25.8.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 bun 1.3.11
-nodejs 22.22.2
+nodejs 25.8.2


### PR DESCRIPTION
## Summary
- update `.tool-versions` from Node.js `22.22.2` to `25.8.2`
- keep local and CI Node.js versions aligned via `mise-action`
- use the latest available Node.js 25 release from the official Node.js distribution index

## Testing
- not run
